### PR TITLE
Fixing incorrect method name in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ public class ChangeMethodNameTestJava {
         Tr.CompilationUnit cu = parser.parse(a, /* which depends on */ b);
 
         Refactor refactor = cu.refactor()
-          .changeName(cu.findMethodCalls("B foo(int)"), "bar");
+          .changeMethodName(cu.findMethodCalls("B foo(int)"), "bar");
 
         Tr.CompilationUnit fixed = refactor.fix();
 


### PR DESCRIPTION
I had to replace the method call with `changeMethodName()` when using 1.2.0 as indicated in the README.md file.