### PR TITLE
add interfaces to Type.Class

### DIFF
--- a/rewrite-core/src/main/kotlin/com/netflix/rewrite/parse/OracleJdkParserVisitor.kt
+++ b/rewrite-core/src/main/kotlin/com/netflix/rewrite/parse/OracleJdkParserVisitor.kt
@@ -1143,8 +1143,10 @@ class OracleJdkParserVisitor(val path: Path, val source: String): TreePathScanne
                                     )
                                 }
 
+                        val symType = sym.type as com.sun.tools.javac.code.Type.ClassType
                         Type.Class.build(sym.className(), fields, type(type.supertype_field, stack.plus(sym)).asClass(),
-                                type.typarams_field?.map { tParam -> type(tParam, stack.plus(sym), shallow = true) }?.filterNotNull() ?: emptyList())
+                                type.typarams_field?.mapNotNull { tParam -> type(tParam, stack.plus(sym), shallow = true) } ?: emptyList(),
+                                symType.interfaces_field?.mapNotNull { i -> type(i, stack.plus(sym), shallow = true) } ?: emptyList())
                     }
                 }
             }

--- a/rewrite-core/src/test/kotlin/com/netflix/rewrite/parse/OracleJdkParserTest.kt
+++ b/rewrite-core/src/test/kotlin/com/netflix/rewrite/parse/OracleJdkParserTest.kt
@@ -17,8 +17,6 @@ package com.netflix.rewrite.parse
 
 import com.netflix.rewrite.ast.Type
 import com.netflix.rewrite.ast.asClass
-import com.netflix.rewrite.ast.hasElementType
-import org.eclipse.jgit.lib.ObjectChecker.type
 import org.junit.Assert.*
 import org.junit.Rule
 import org.junit.Test

--- a/rewrite-core/src/test/kotlin/com/netflix/rewrite/parse/OracleJdkParserTest.kt
+++ b/rewrite-core/src/test/kotlin/com/netflix/rewrite/parse/OracleJdkParserTest.kt
@@ -15,9 +15,11 @@
  */
 package com.netflix.rewrite.parse
 
+import com.netflix.rewrite.ast.Type
 import com.netflix.rewrite.ast.asClass
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertTrue
+import com.netflix.rewrite.ast.hasElementType
+import org.eclipse.jgit.lib.ObjectChecker.type
+import org.junit.Assert.*
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
@@ -85,5 +87,21 @@ class OracleJdkParserTest {
 
         // still able to find references to B even when "cannot find symbols" abound!
         assertTrue(a.findType("b.B").map { a.cursor(it)?.enclosingVariableDecl() }.filterNotNull().size >= 4)
+    }
+
+    @Test
+    fun parserIncludesTypeInterfaces() {
+        val a = OracleJdkParser().parse("""
+            |package a;
+            |import java.util.HashSet;
+            |import java.util.Set;
+            |public class A {
+            |   Set<String> set = new HashSet<String>();
+            }
+        """)
+
+        val hashSet = a.findType("java.util.HashSet")[1]    // first element is the import
+        assertNotNull(hashSet.type.asClass())
+        assertTrue(hashSet.type.asClass()!!.interfaces.any { (it as Type.ShallowClass).fullyQualifiedName == "java.util.Set" })
     }
 }


### PR DESCRIPTION
Hi! I've found this library very useful and appreciate all the work that's gone into it so far. 

One piece of information I'd like access to in `Type.Class` is the interfaces implemented by the class. I've made a PR here to plumb through this information from the Sun classes, but I'm not very familiar with the Sun API or with Kotlin, so please let me know if you have feedback.