### PR TITLE
Fix superfluous label colon

### DIFF
--- a/rewrite-core/src/main/kotlin/com/netflix/rewrite/ast/visitor/PrintVisitor.kt
+++ b/rewrite-core/src/main/kotlin/com/netflix/rewrite/ast/visitor/PrintVisitor.kt
@@ -34,7 +34,6 @@ class PrintVisitor : AstVisitor<String>("") {
             is Tr.Assign, is Tr.AssignOp, is Tr.Break, is Tr.Continue, is Tr.MethodInvocation -> ";"
             is Tr.NewClass, is Tr.Return, is Tr.Throw, is Tr.Unary, is Tr.VariableDecls -> ";"
             is Tr.DoWhileLoop, is Tr.Empty, is Tr.Assert -> ";"
-            is Tr.Label -> ":"
             is Tr.MethodDecl -> if(statement.body == null) ";" else ""
             else -> ""
         }

--- a/rewrite-core/src/test/kotlin/com/netflix/rewrite/ast/LabelTest.kt
+++ b/rewrite-core/src/test/kotlin/com/netflix/rewrite/ast/LabelTest.kt
@@ -25,17 +25,41 @@ abstract class LabelTest(p: Parser): Parser by p {
     
     @Test
     fun labeledWhileLoop() {
-        val a = parse("""
-            public class A {
-                public void test() {
-                    labeled: while(true) {
-                    }
-                }
-            }
-        """)
+        var orig = """
+            |public class A {
+            |    public void test() {
+            |        labeled: while(true) {
+            |        }
+            |    }
+            |}
+        """.trimMargin()
+        val a = parse(orig)
         
         val labeled = a.firstMethodStatement() as Tr.Label
         assertEquals("labeled", labeled.label.simpleName)
         assertTrue(labeled.statement is Tr.WhileLoop)
+        assertEquals("Should recreate original", orig, a.print())
+    }
+
+    @Test
+    fun nonEmptyLabeledWhileLoop() {
+        val orig = """
+            |public class A {
+            |    public void test() {
+            |        outer: while(true) {
+            |            while(true) {
+            |                break outer;
+            |            }
+            |        }
+            |    }
+            |}
+        """.trimMargin()
+
+        val a = parse(orig)
+
+        val labeled = a.firstMethodStatement() as Tr.Label
+        assertEquals("outer", labeled.label.simpleName)
+        assertTrue(labeled.statement is Tr.WhileLoop)
+        assertEquals("Should recreate original", orig, a.print())
     }
 }


### PR DESCRIPTION
Fixes https://github.com/Netflix-Skunkworks/rewrite/issues/12

Print statement visitor previously added a `:` after a `Label` was visited via `visitStatement`, when it is already being added by the `visitLabel` method which `visitStatement` defers to.