### PR TITLE
Improve GRADLE build Performance

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ buildscript {
 
 allprojects {
     tasks.withType(Test).configureEach {
-        maxParallelForks = 4
+        maxParallelForks = Runtime.runtime.availableProcessors().intdiv(2) ?: 1
         if (!project.hasProperty("createReports")) {
             reports.html.required = false
             reports.junitXml.required = false

--- a/build.gradle
+++ b/build.gradle
@@ -14,6 +14,14 @@ buildscript {
 }
 
 allprojects {
+    tasks.withType(Test).configureEach {
+        maxParallelForks = 4
+        if (!project.hasProperty("createReports")) {
+            reports.html.required = false
+            reports.junitXml.required = false
+        }
+    }
+
     apply plugin: 'nebula.netflixoss'
 
     group = 'com.netflix.devinsight.rewrite'


### PR DESCRIPTION

[Parallel test execution maxParallelForks](https://docs.gradle.org/current/userguide/performance.html#parallel_test_execution). Gradle can run multiple test cases in parallel by setting `maxParallelForks`.

[Disable report generation](https://docs.gradle.org/current/userguide/performance.html#report_generation). We can conditionally disable it by setting `reports.html.required = false; reports.junitXml.required = false`. If you need to generate reports, add `-PcreateReports` to the end of Gradle's build command line.

=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
